### PR TITLE
delete instance eval

### DIFF
--- a/mrblib/mrb_mutex.rb
+++ b/mrblib/mrb_mutex.rb
@@ -17,7 +17,7 @@ class Mutex
     loop do
       count += 1
       if self.try_lock
-        instance_eval &b
+        b.call
         break
       elsif timeout < retrytime * count
         self.unlock


### PR DESCRIPTION
呼び出し元のインスタンス変数などがロック出来ないため、instance_evalを除去しました。